### PR TITLE
Update rollup condition to support Web Workers

### DIFF
--- a/lib/deploy/pack.js
+++ b/lib/deploy/pack.js
@@ -36,7 +36,7 @@ export let ROLLUP;
 export async function setRollup(rollup) {
     if (ROLLUP) return;
     if (!rollup || typeof rollup === "string") {
-        if (typeof window !== "undefined") {
+        if (typeof window !== "undefined" || typeof WorkerGlobalScope !== 'undefined') {
             rollup = await import(
                 (rollup || "https://cdn.jsdelivr.net/npm/@rollup/browser@3.29.4/+esm")
                 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bring-your-own-storage-utilities",
-  "version": "0.0.1333",
+  "version": "0.0.1334",
   "description": "Utilities for storage devices you bring on your own",
   "main": "index.js",
   "browser": "dist/all.min.js",


### PR DESCRIPTION
Modified the setRollup function to check for WorkerGlobalScope in addition to the window object. This enables rollup to be imported in Web Worker environments. Also incremented the package version to 0.0.1334.

fixes https://github.com/zacharygriffee/bring-your-own-storage-utilities/issues/10#issue-2439356642